### PR TITLE
13 / Access tokens and refresh tokens

### DIFF
--- a/app/src/main/java/com/ataulm/whatsnext/Token.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/Token.kt
@@ -1,3 +1,3 @@
 package com.ataulm.whatsnext
 
-data class Token(val accessToken: String, val refreshToken: String, val expiryMillisSinceEpoch: Long)
+data class Token(val accessToken: String, val refreshToken: String)

--- a/app/src/main/java/com/ataulm/whatsnext/TokensStore.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/TokensStore.kt
@@ -9,7 +9,6 @@ class TokensStore private constructor(private val preferences: SharedPreferences
         preferences.edit()
                 .putString(KEY_ACCESS_TOKEN_VALUE, token.accessToken)
                 .putString(KEY_REFRESH_TOKEN_VALUE, token.refreshToken)
-                .putLong(KEY_ACCESS_TOKEN_EXPIRY, token.expiryMillisSinceEpoch)
                 .apply()
     }
 
@@ -17,27 +16,27 @@ class TokensStore private constructor(private val preferences: SharedPreferences
         preferences.edit()
                 .remove(KEY_ACCESS_TOKEN_VALUE)
                 .remove(KEY_REFRESH_TOKEN_VALUE)
-                .remove(KEY_ACCESS_TOKEN_EXPIRY)
                 .apply()
     }
 
     val token: Token?
         get() {
-            if (preferences.contains(KEY_ACCESS_TOKEN_VALUE) && preferences.contains(KEY_ACCESS_TOKEN_EXPIRY)) {
-                val accessToken = preferences.getString(KEY_ACCESS_TOKEN_VALUE, "")
-                val refreshToken = preferences.getString(KEY_REFRESH_TOKEN_VALUE, "")
-                val expiry = preferences.getLong(KEY_ACCESS_TOKEN_EXPIRY, 0)
-                return Token(accessToken!!, refreshToken!!, expiry)
+            if (preferences.contains(KEY_ACCESS_TOKEN_VALUE) && preferences.contains(KEY_REFRESH_TOKEN_VALUE)) {
+                val accessToken = preferences.getString(KEY_ACCESS_TOKEN_VALUE, "")!!
+                val refreshToken = preferences.getString(KEY_REFRESH_TOKEN_VALUE, "")!!
+                return Token(accessToken, refreshToken)
             }
             return null
         }
 
     companion object {
 
-        @JvmStatic private val FILE_NAME = BuildConfig.APPLICATION_ID + ".tokens_store"
-        @JvmStatic private val KEY_ACCESS_TOKEN_VALUE = "access.value"
-        @JvmStatic private val KEY_REFRESH_TOKEN_VALUE = "refresh.value"
-        @JvmStatic private val KEY_ACCESS_TOKEN_EXPIRY = "access.expiry"
+        @JvmStatic
+        private val FILE_NAME = BuildConfig.APPLICATION_ID + ".tokens_store"
+        @JvmStatic
+        private val KEY_ACCESS_TOKEN_VALUE = "access.value"
+        @JvmStatic
+        private val KEY_REFRESH_TOKEN_VALUE = "refresh.value"
 
         @JvmStatic
         fun create(context: Context): TokensStore {

--- a/app/src/main/java/com/ataulm/whatsnext/WhatsNextService.java
+++ b/app/src/main/java/com/ataulm/whatsnext/WhatsNextService.java
@@ -11,16 +11,10 @@ import com.ataulm.whatsnext.api.LetterboxdApi;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.reactivex.Completable;
-import io.reactivex.CompletableSource;
 import io.reactivex.Observable;
-import io.reactivex.ObservableSource;
-import io.reactivex.ObservableTransformer;
 import io.reactivex.Single;
-import io.reactivex.functions.Action;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Function;
-import retrofit2.HttpException;
 
 public class WhatsNextService {
 
@@ -46,8 +40,7 @@ public class WhatsNextService {
             public Token apply(AuthTokenApiResponse authTokenApiResponse) {
                 return new Token(
                         authTokenApiResponse.getAccessToken(),
-                        authTokenApiResponse.getRefreshToken(),
-                        authTokenApiResponse.getSecondsUntilExpiry()
+                        authTokenApiResponse.getRefreshToken()
                 );
             }
         };

--- a/app/src/main/java/com/ataulm/whatsnext/WhatsNextService.java
+++ b/app/src/main/java/com/ataulm/whatsnext/WhatsNextService.java
@@ -25,13 +25,11 @@ import retrofit2.HttpException;
 public class WhatsNextService {
 
     private final LetterboxdApi letterboxdApi;
-    private final TokensStore tokensStore;
     private final FilmSummaryConverter filmSummaryConverter;
     private final FilmRelationshipConverter filmRelationshipConverter;
 
-    public WhatsNextService(LetterboxdApi letterboxdApi, TokensStore tokensStore, FilmSummaryConverter filmSummaryConverter, FilmRelationshipConverter filmRelationshipConverter) {
+    public WhatsNextService(LetterboxdApi letterboxdApi, FilmSummaryConverter filmSummaryConverter, FilmRelationshipConverter filmRelationshipConverter) {
         this.letterboxdApi = letterboxdApi;
-        this.tokensStore = tokensStore;
         this.filmSummaryConverter = filmSummaryConverter;
         this.filmRelationshipConverter = filmRelationshipConverter;
     }
@@ -87,48 +85,7 @@ public class WhatsNextService {
                         );
                     }
                 }
-        )
-                .toObservable()
-                .compose(this.<Film>refreshAccessTokenIfNecessary());
-    }
-
-    private <T> ObservableTransformer<T, T> refreshAccessTokenIfNecessary() {
-        return new ObservableTransformer<T, T>() {
-            @Override
-            public ObservableSource<T> apply(final Observable<T> upstream) {
-                return upstream.onErrorResumeNext(new Function<Throwable, ObservableSource<T>>() {
-                    @Override
-                    public ObservableSource<T> apply(Throwable throwable) {
-                        if (throwable instanceof HttpException && ((HttpException) throwable).code() == 401) {
-                            return refreshAccessToken().andThen(upstream);
-                        } else {
-                            return Observable.error(throwable);
-                        }
-                    }
-                });
-            }
-        };
-    }
-
-    private Completable refreshAccessToken() {
-        Token token = tokensStore.getToken();
-        if (token == null) {
-            return Completable.error(new UserRequiresSignInException());
-        }
-        String refreshToken = tokensStore.getToken().getRefreshToken();
-        return letterboxdApi.refreshAuthToken(refreshToken, "refresh_token")
-                .map(toToken())
-                .flatMapCompletable(new Function<Token, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(final Token token) {
-                        return Completable.fromAction(new Action() {
-                            @Override
-                            public void run() {
-                                tokensStore.store(token);
-                            }
-                        });
-                    }
-                });
+        ).toObservable();
     }
 }
 

--- a/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
@@ -7,16 +7,6 @@ import retrofit2.http.*
 @Target(AnnotationTarget.FUNCTION)
 annotation class RequiresAuthenticatedUser
 
-interface LetterboxdRefreshAccessTokenApi {
-
-    @FormUrlEncoded
-    @POST("auth/token")
-    fun refreshAuthToken(
-            @Field("refresh_token") refreshToken: String,
-            @Field("grant_type") grantType: String = "refresh_token"
-    ): AuthTokenApiResponse
-}
-
 interface LetterboxdApi {
 
     @FormUrlEncoded
@@ -40,6 +30,9 @@ interface LetterboxdApi {
 
 data class AuthTokenApiResponse(
         @SerializedName("access_token") val accessToken: String,
+        /**
+         * TODO: is this seconds or millis? because [com.ataulm.whatsnext.Token] says "millis" 😅
+         */
         @SerializedName("expires_in") val secondsUntilExpiry: Long,
         @SerializedName("refresh_token") val refreshToken: String
 )

--- a/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
@@ -7,6 +7,16 @@ import retrofit2.http.*
 @Target(AnnotationTarget.FUNCTION)
 annotation class RequiresAuthenticatedUser
 
+interface LetterboxdRefreshAccessTokenApi {
+
+    @FormUrlEncoded
+    @POST("auth/token")
+    fun refreshAuthToken(
+            @Field("refresh_token") refreshToken: String,
+            @Field("grant_type") grantType: String = "refresh_token"
+    ): AuthTokenApiResponse
+}
+
 interface LetterboxdApi {
 
     @FormUrlEncoded

--- a/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
@@ -4,6 +4,9 @@ import com.google.gson.annotations.SerializedName
 import io.reactivex.Single
 import retrofit2.http.*
 
+@Target(AnnotationTarget.FUNCTION)
+annotation class RequiresAuthenticatedUser
+
 interface LetterboxdApi {
 
     @FormUrlEncoded
@@ -27,6 +30,7 @@ interface LetterboxdApi {
     @GET("film/{id}")
     fun film(@Path("id") letterboxdId: String): Single<ApiFilm>
 
+    @RequiresAuthenticatedUser
     @GET("film/{id}/me")
     fun filmRelationship(@Path("id") letterboxdId: String): Single<ApiFilmRelationship>
 }

--- a/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
@@ -27,13 +27,6 @@ interface LetterboxdApi {
             @Field("grant_type") grantType: String = "password"
     ): Single<AuthTokenApiResponse>
 
-    @FormUrlEncoded
-    @POST("auth/token")
-    fun refreshAuthToken(
-            @Field("refresh_token") refreshToken: String,
-            @Field("grant_type") grantType: String = "refresh_token"
-    ): Single<AuthTokenApiResponse>
-
     @GET("search")
     fun search(@Query("input") searchTerm: String): Single<ApiSearchResponse>
 

--- a/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApi.kt
@@ -30,9 +30,5 @@ interface LetterboxdApi {
 
 data class AuthTokenApiResponse(
         @SerializedName("access_token") val accessToken: String,
-        /**
-         * TODO: is this seconds or millis? because [com.ataulm.whatsnext.Token] says "millis" 😅
-         */
-        @SerializedName("expires_in") val secondsUntilExpiry: Long,
         @SerializedName("refresh_token") val refreshToken: String
 )

--- a/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApiFactory.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/api/LetterboxdApiFactory.kt
@@ -151,7 +151,7 @@ private class RefreshAccessTokenInterceptor(
         return refreshAccessTokenApi.refreshAuthToken(refreshToken).execute()
                 .let { response ->
                     response.body()?.let {
-                        Token(it.accessToken, it.refreshToken, it.secondsUntilExpiry)
+                        Token(it.accessToken, it.refreshToken)
                     }
                 }
     }

--- a/app/src/main/java/com/ataulm/whatsnext/di/AppComponent.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/di/AppComponent.kt
@@ -1,7 +1,6 @@
 package com.ataulm.whatsnext.di;
 
 import android.app.Application
-import android.content.Context
 import com.ataulm.support.Clock
 import com.ataulm.whatsnext.BuildConfig
 import com.ataulm.whatsnext.TokensStore
@@ -43,7 +42,7 @@ internal object AppModule {
         val letterboxdApi = letterboxdApi(tokensStore)
         val filmSummaryConverter = FilmSummaryConverter()
         val filmRelationshipConverter = FilmRelationshipConverter()
-        return WhatsNextService(letterboxdApi, tokensStore, filmSummaryConverter, filmRelationshipConverter)
+        return WhatsNextService(letterboxdApi, filmSummaryConverter, filmRelationshipConverter)
     }
 
    private fun letterboxdApi(tokensStore: TokensStore): LetterboxdApi {


### PR DESCRIPTION
Fixes #13

- adds annotation `RequiresAuthenticatedUser` to differentiate between endpoints
- moves the refresh access token behavior into an application interceptor in OkHttpClient