### PR TITLE
Fix scroll position on rotation

### DIFF
--- a/app/src/main/java/com/ataulm/whatsnext/FilmSummariesAdapter.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/FilmSummariesAdapter.kt
@@ -9,6 +9,10 @@ class FilmSummariesAdapter(
         private val callback: FilmSummaryViewHolder.Callback
 ) : ListAdapter<FilmSummary, FilmSummaryViewHolder>(Differ) {
 
+    init {
+        stateRestorationPolicy = StateRestorationPolicy.PREVENT_WHEN_EMPTY
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FilmSummaryViewHolder {
         return inflateView(parent)
     }

--- a/app/src/main/java/com/ataulm/whatsnext/film/PeopleWidget.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/film/PeopleWidget.kt
@@ -1,15 +1,15 @@
 package com.ataulm.whatsnext.film
 
 import android.content.Context
-import androidx.core.view.ViewCompat
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.RecyclerView.Adapter
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.core.view.ViewCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.Adapter
 import com.ataulm.whatsnext.R
 import kotlinx.android.synthetic.main.merge_people_widget.view.*
 import kotlinx.android.synthetic.main.view_item_people.view.*
@@ -45,6 +45,10 @@ class PeopleWidget constructor(context: Context, attrs: AttributeSet) : LinearLa
     }
 
     private class PeopleAdapter(private val people: List<PersonViewModel>) : Adapter<PersonViewHolder>() {
+
+        init {
+            stateRestorationPolicy = StateRestorationPolicy.PREVENT_WHEN_EMPTY
+        }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PersonViewHolder {
             return PersonViewHolder.create(parent)

--- a/app/src/main/java/com/ataulm/whatsnext/search/SearchActivity.kt
+++ b/app/src/main/java/com/ataulm/whatsnext/search/SearchActivity.kt
@@ -97,6 +97,10 @@ private class PopularFilmsThisWeekAdapter(
         private val callback: FilmSummaryViewHolder.Callback
 ) : PagingDataAdapter<FilmSummary, FilmSummaryViewHolder>(FilmDiffer) {
 
+    init {
+        stateRestorationPolicy = StateRestorationPolicy.PREVENT_WHEN_EMPTY
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FilmSummaryViewHolder {
         return FilmSummaryViewHolder.inflateView(parent)
     }


### PR DESCRIPTION
Back in my day we used to avoid setting the adapter on the recyclerview until after the adapter was populated. Bit of a pain.

This [blog post](https://medium.com/androiddevelopers/restore-recyclerview-scroll-position-a8fbdc9a9334) from Florina Muntenescu documents a new adapter property which can be used to block state restoration until the adapter is non-empty.

Fixes #25

